### PR TITLE
Change `site` to extract API docs into its own `api` extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- `site` to extract API docs into its own `api` extension
+
 ### Deprecated
 
 ### Removed

--- a/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/extensions/config/_internal/createAndConfigureHubdleConfigExtensions.kt
+++ b/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/extensions/config/_internal/createAndConfigureHubdleConfigExtensions.kt
@@ -7,6 +7,7 @@ import com.javiersc.hubdle.extensions.config.analysis.reports.HubdleConfigAnalys
 import com.javiersc.hubdle.extensions.config.binary.compatibility.validator.HubdleConfigBinaryCompatibilityValidatorExtension
 import com.javiersc.hubdle.extensions.config.coverage.HubdleConfigCoverageExtension
 import com.javiersc.hubdle.extensions.config.documentation.HubdleConfigDocumentationExtension
+import com.javiersc.hubdle.extensions.config.documentation.api.HubdleConfigDocumentationApiExtension
 import com.javiersc.hubdle.extensions.config.documentation.changelog.HubdleConfigDocumentationChangelogExtension
 import com.javiersc.hubdle.extensions.config.documentation.readme.HubdleConfigDocumentationReadmeExtension
 import com.javiersc.hubdle.extensions.config.documentation.readme.badges.HubdleConfigDocumentationReadmeBadgesExtension
@@ -47,6 +48,7 @@ private fun HubdleState.configureAnalysisExtensions() {
 
 private fun HubdleState.configureDocumentationExtensions() {
     createExtension<HubdleConfigDocumentationExtension> {
+        createExtension<HubdleConfigDocumentationApiExtension>()
         createExtension<HubdleConfigDocumentationChangelogExtension>()
         createExtension<HubdleConfigDocumentationReadmeExtension> {
             createExtension<HubdleConfigDocumentationReadmeBadgesExtension>()

--- a/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/extensions/config/documentation/HubdleConfigDocumentationExtension.kt
+++ b/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/extensions/config/documentation/HubdleConfigDocumentationExtension.kt
@@ -4,6 +4,7 @@ import com.javiersc.hubdle.extensions.HubdleDslMarker
 import com.javiersc.hubdle.extensions._internal.getHubdleExtension
 import com.javiersc.hubdle.extensions.apis.HubdleEnableableExtension
 import com.javiersc.hubdle.extensions.apis.enableAndExecute
+import com.javiersc.hubdle.extensions.config.documentation.api.HubdleConfigDocumentationApiExtension
 import com.javiersc.hubdle.extensions.config.documentation.changelog.HubdleConfigDocumentationChangelogExtension
 import com.javiersc.hubdle.extensions.config.documentation.readme.HubdleConfigDocumentationReadmeExtension
 import com.javiersc.hubdle.extensions.config.documentation.site.HubdleConfigDocumentationSiteExtension
@@ -24,6 +25,14 @@ constructor(
 
     override val requiredExtensions: Set<HubdleEnableableExtension>
         get() = setOf(hubdleConfig)
+
+    public val api: HubdleConfigDocumentationApiExtension
+        get() = getHubdleExtension()
+
+    @HubdleDslMarker
+    public fun api(action: Action<HubdleConfigDocumentationApiExtension> = Action {}) {
+        api.enableAndExecute(action)
+    }
 
     public val changelog: HubdleConfigDocumentationChangelogExtension
         get() = getHubdleExtension()

--- a/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/extensions/config/documentation/api/HubdleConfigDocumentationApiExtension.kt
+++ b/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/extensions/config/documentation/api/HubdleConfigDocumentationApiExtension.kt
@@ -1,0 +1,57 @@
+package com.javiersc.hubdle.extensions.config.documentation.api
+
+import com.javiersc.hubdle.extensions.HubdleDslMarker
+import com.javiersc.hubdle.extensions._internal.ApplicablePlugin.Scope
+import com.javiersc.hubdle.extensions._internal.Configurable.Priority
+import com.javiersc.hubdle.extensions._internal.PluginId
+import com.javiersc.hubdle.extensions._internal.getHubdleExtension
+import com.javiersc.hubdle.extensions._internal.hasKotlinGradlePlugin
+import com.javiersc.hubdle.extensions.apis.HubdleConfigurableExtension
+import com.javiersc.hubdle.extensions.apis.HubdleEnableableExtension
+import com.javiersc.hubdle.extensions.config.documentation.hubdleDocumentation
+import javax.inject.Inject
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.dokka.gradle.DokkaTaskPartial
+
+@HubdleDslMarker
+public open class HubdleConfigDocumentationApiExtension
+@Inject
+constructor(
+    project: Project,
+) : HubdleConfigurableExtension(project) {
+
+    override val isEnabled: Property<Boolean> = property { false }
+
+    override val requiredExtensions: Set<HubdleEnableableExtension>
+        get() = setOf(hubdleDocumentation)
+
+    override val priority: Priority = Priority.P3
+
+    override fun Project.defaultConfiguration() {
+        applicablePlugin(
+            priority = Priority.P4,
+            scope = Scope.CurrentProject,
+            pluginId = PluginId.JetbrainsDokka
+        )
+
+        configurable {
+            if (project.hasKotlinGradlePlugin) {
+                tasks.withType<DokkaTaskPartial> {
+                    dokkaSourceSets.configureEach { set ->
+                        val includes: List<String> = buildList {
+                            if (projectDir.resolve("MODULE.md").exists()) add("MODULE.md")
+                            if (projectDir.resolve("README.md").exists()) add("README.md")
+                        }
+
+                        if (includes.isNotEmpty()) set.includes.from(includes)
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal val HubdleEnableableExtension.hubdleApi: HubdleConfigDocumentationApiExtension
+    get() = getHubdleExtension()

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/build.gradle.kts
@@ -9,6 +9,7 @@ allprojects {
 hubdle {
     config {
         documentation {
+            api()
             site()
         }
 

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/libraries/sub-two/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/libraries/sub-two/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/libraries/sub/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/libraries/sub/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/library/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/library/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/more/sub-dir/sub/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/more/sub-dir/sub/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/more/sub/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-1/more/sub/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/build.gradle.kts
@@ -9,6 +9,7 @@ allprojects {
 hubdle {
     config {
         documentation {
+            api()
             site {
                 reports {
                     allTests.set(false)

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/libraries/sub-two/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/libraries/sub-two/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/libraries/sub/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/libraries/sub/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/library/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/library/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/more/sub-dir/sub/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/more/sub-dir/sub/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }

--- a/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/more/sub/build.gradle.kts
+++ b/hubdle-gradle-plugin/test/resources/config/documentation/site/snapshot-2/more/sub/build.gradle.kts
@@ -4,6 +4,9 @@ plugins {
 
 hubdle {
     config {
+        documentation {
+            api()
+        }
         versioning {
             isEnabled.set(false)
         }


### PR DESCRIPTION
Fixes https://github.com/JavierSegoviaCordoba/hubdle/issues/463