### PR TITLE
Change Java version to 17 in molecule feature test

### DIFF
--- a/hubdle-gradle-plugin/testFunctional/resources/kotlin/jvm/features/molecule/build.gradle.kts
+++ b/hubdle-gradle-plugin/testFunctional/resources/kotlin/jvm/features/molecule/build.gradle.kts
@@ -19,6 +19,7 @@ hubdle {
                 }
                 compose()
                 coroutines()
+                jvmVersion(JavaVersion.VERSION_17)
                 molecule()
             }
         }


### PR DESCRIPTION
This pull request makes a minor update to the build configuration by specifying the Java version for the JVM target.

- Build configuration:
  * Added `jvmVersion(JavaVersion.VERSION_17)` to the `hubdle {` block in `build.gradle.kts` to explicitly set the Java version to 17.