### PR TITLE
Change Spotless Ktfmt configuration to manage trailing commas and remove unused imports

### DIFF
--- a/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/project/extensions/config/format/HubdleConfigFormatExtension.kt
+++ b/hubdle-gradle-plugin/main/kotlin/com/javiersc/hubdle/project/extensions/config/format/HubdleConfigFormatExtension.kt
@@ -3,6 +3,7 @@ package com.javiersc.hubdle.project.extensions.config.format
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.diffplug.gradle.spotless.SpotlessExtension
 import com.diffplug.gradle.spotless.SpotlessExtensionPredeclare
+import com.diffplug.spotless.kotlin.KtfmtStep.TrailingCommaManagementStrategy.ONLY_ADD
 import com.javiersc.hubdle.project.extensions.HubdleDslMarker
 import com.javiersc.hubdle.project.extensions._internal.ApplicablePlugin.Scope
 import com.javiersc.hubdle.project.extensions._internal.fallbackAction
@@ -122,7 +123,10 @@ public open class HubdleConfigFormatExtension @Inject constructor(project: Proje
                 kotlin { kotlin ->
                     kotlin.target(includes.get())
                     kotlin.targetExclude(excludes.get())
-                    kotlin.ktfmt(ktfmtVersion.get()).kotlinlangStyle()
+                    kotlin.ktfmt(ktfmtVersion.get()).kotlinlangStyle().configure {
+                        it.setRemoveUnusedImports(true)
+                        it.setTrailingCommaManagementStrategy(ONLY_ADD)
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request updates the Kotlin formatting configuration in the `HubdleConfigFormatExtension` to improve code style enforcement. The main changes involve enhancing the Spotless/Ktfmt setup to automatically remove unused imports and consistently add trailing commas where appropriate.

**Kotlin formatting improvements:**

* Updated the `ktfmt` configuration to enable automatic removal of unused imports and to set the trailing comma management strategy to always add trailing commas (`ONLY_ADD`).
* Imported the necessary `ONLY_ADD` enum from `com.diffplug.spotless.kotlin.KtfmtStep.TrailingCommaManagementStrategy` to support the new trailing comma strategy.